### PR TITLE
Fix Snap package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,12 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+
+###Snap###
+
+parts/
+prime/
+snap/
+stage/
+*.snap

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ See the difference by disabling this optimization using the `-0` option. Or just
 
 ## "News"
 
-- We'd appreciate endorsement here if you like the tool: https://github.com/k4m4/terminals-are-sexy/pull/198 
-- Help wanted: If you are familiar with make and snap, please suggest how to fix our make file for snap 
+- We'd appreciate endorsement here if you like the tool: https://github.com/k4m4/terminals-are-sexy/pull/198
 
 ## Installation
 
@@ -38,6 +37,8 @@ The shell will expand wildcards. By default, thumbnails and file names will be d
    https://build.opensuse.org/package/show/home:megamaced/terminalimageviewer
  - bperel has created a Docker image:
    https://hub.docker.com/r/bperel/terminalimageviewer
+ - teresaejunior has created a snapcraft.yaml file, which you can use to build a Snap package.
+   tiv will soon be available in the Snap Store.
 
 ## Common problems
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ The shell will expand wildcards. By default, thumbnails and file names will be d
    https://build.opensuse.org/package/show/home:megamaced/terminalimageviewer
  - bperel has created a Docker image:
    https://hub.docker.com/r/bperel/terminalimageviewer
- - teresaejunior has created a snapcraft.yaml file, which you can use to build a Snap package.
-   tiv will soon be available in the Snap Store.
+ - teresaejunior has created a snapcraft.yaml file, which can build a Snap package with `sudo docker run -it --rm -v "$PWD:$PWD" -w "$PWD" snapcore/snapcraft sh -c 'apt-get update && snapcraft'`, and then installed with `sudo snap install --dangerous ./*.snap`, until tiv is available in the Snap Store.
 
 ## Common problems
 
@@ -58,4 +57,3 @@ If multiple images match the filename spec, thumbnails are shown.
 The top image was generated with the character optimization disabled via the `-0` option.
 
 ![Comparison](https://i.imgur.com/OzdCeh6.png)
-

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,19 +2,16 @@ name: tiv
 version: "v1.0.0"
 summary: Terminal Image Viewer
 description: |
-  NOTE: This snap file doesn't work yet. Checked in for dev purposes.
-  tiv is a small C++ program to display images in a (modern) terminal using RGB ANSI codes
-  and unicode block graphic characters.
-
-confinement: devmode
+  tiv is a small C++ program to display images in a (modern) terminal using
+  RGB ANSI codes and unicode block graphic characters.
 
 apps:
   tiv:
-    command: tiv
-
+    command: usr/bin/tiv
+    plugs: [home]
 
 parts:
-  tiv: 
+  tiv:
     plugin: make
     source-type: tar
     source: https://github.com/stefanhaustein/TerminalImageViewer/archive/v1.0.0.tar.gz
@@ -23,10 +20,54 @@ parts:
       - g++
       - make
       - imagemagick
-
-
-
-    
-    
-
-
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/bin/
+      install $SNAPCRAFT_PART_BUILD/tiv $SNAPCRAFT_PART_INSTALL/usr/bin/
+  imagemagick:
+    plugin: autotools
+    source: https://www.imagemagick.org/download/releases/ImageMagick-7.0.8-19.tar.xz
+    source-type: tar
+    configflags:
+      - --enable-hdri=yes
+      - --enable-shared=yes
+      - --enable-static=yes
+      - --with-autotrace=yes
+      - --with-fpx=no
+      - --with-gnu-ld=yes
+      - --with-gslib=yes
+      - --with-modules=no
+      - --with-quantum-depth=32
+      - --with-rsvg=yes
+    build-packages:
+      - autoconf
+      - build-essential
+      - fftw-dev
+      - libautotrace-dev
+      - libbz2-dev
+      - libdjvulibre-dev
+      - libfftw3-dev
+      - libfontconfig1-dev
+      - libfreetype6-dev
+      - libgs-dev
+      - libgvc6
+      - libjbig-dev
+      - libjpeg-dev
+      - liblcms2-dev
+      - liblqr-1-0-dev
+      - libltdl-dev
+      - libmagick++-dev
+      - libopenexr-dev
+      - libopenjp2-7-dev
+      - libpango1.0-dev
+      - libperl-dev
+      - libpng12-dev
+      - librsvg2-dev
+      - libtiff5-dev
+      - libwebp-dev
+      - libwmf-dev
+      - libx11-dev
+      - lzma-dev
+      - ocl-icd-opencl-dev
+      - perlmagick
+      - zlib1g-dev


### PR DESCRIPTION
1) `mkdir / install...` will workaround Makefile limitations and copy the binary manually.
2) `plugs: [home]` is needed to open user image files.
3) I don't know whether ImageMagick is needed for compiling too, or only during runtime. If not needed for compiling, the line `- imagemagick` can be removed safely.
4) For the runtime, building ImageMagick is needed, because searching for fixed paths in the filesystem is a known limitation of ImageMagick. That could be easily solved in the future with the Snap's experimental feature called `layout:`.

The snap was tested successfully. Please, let me know when you upload the package to the store!