### PR TITLE
Fix tall thumbnails

### DIFF
--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -513,6 +513,7 @@ int main(int argc, char* argv[]) {
     int cw = (((maxWidth / 4) - 2 * (columns - 1)) / columns);
     int tw = cw * 4;
     cimg_library::CImg<unsigned char> image(tw * columns + 2 * 4 * (columns - 1), tw, 1, 3);
+    size maxThumbSize(tw, tw);
     
     while (index < file_names.size()) {
       image.fill(0);
@@ -524,9 +525,9 @@ int main(int argc, char* argv[]) {
 	  cimg_library::CImg<unsigned char> original = load_rgb_CImg(name.c_str());
 	  unsigned int cut = name.find_last_of("/");
 	  sb += cut == std::string::npos ? name : name.substr(cut + 1);
-	  int th = original.height() * tw / original.width();
-	  original.resize(tw, th, 1, -100, 5);
-	  image.draw_image(count * (tw + 8), (tw - th) / 2, 0, 0, original);
+	  size newSize = fit_within(maxThumbSize, size(original));
+	  original.resize(newSize.width, newSize.height, 1, -100, 5);
+	  image.draw_image(count * (tw + 8), (tw - newSize.height) / 2, 0, 0, original);
 	  count++;
 	  unsigned int sl = count * (cw + 2);
 	  sb.resize(sl - 2, ' ');

--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -391,10 +391,10 @@ struct size {
   }
   unsigned int width;
   unsigned int height;
+  size operator*(double scale) {
+    return size(width*scale, height*scale);
+  }
 };
-size operator*(size lhs, double scale) {
-  return size(lhs.width*scale, lhs.height*scale);
-}
 std::ostream& operator<<(std::ostream& stream, size sz) {
   stream << sz.width << "x" << sz.height;
   return stream;

--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -395,6 +395,11 @@ struct size {
 size operator*(size lhs, double scale) {
   return size(lhs.width*scale, lhs.height*scale);
 }
+std::ostream& operator<<(std::ostream& stream, size sz) {
+  stream << sz.width << "x" << sz.height;
+  return stream;
+}
+
 
 size fit_within(size container, size object) {
   double scale = std::min(container.width / (double) object.width, container.height / (double) object.height);

--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -391,8 +391,12 @@ struct size {
   }
   unsigned int width;
   unsigned int height;
-  size operator*(double scale) {
+  size scaled(double scale) {
     return size(width*scale, height*scale);
+  }
+  size fitted_within(size container) {
+    double scale = std::min(container.width / (double) width, container.height / (double) height);
+    return scaled(scale);
   }
 };
 std::ostream& operator<<(std::ostream& stream, size sz) {
@@ -401,10 +405,6 @@ std::ostream& operator<<(std::ostream& stream, size sz) {
 }
 
 
-size fit_within(size container, size object) {
-  double scale = std::min(container.width / (double) object.width, container.height / (double) object.height);
-  return object * scale;
-}
 
 
 void emit_usage() {
@@ -497,7 +497,7 @@ int main(int argc, char* argv[]) {
 	cimg_library::CImg<unsigned char> image = load_rgb_CImg(file_names[i].c_str());
       
 	if (image.width() > maxWidth || image.height() > maxHeight) {
-	  size new_size = fit_within(size(maxWidth,maxHeight), size(image));
+	  size new_size = size(image).fitted_within(size(maxWidth,maxHeight));
 	  image.resize(new_size.width, new_size.height, -100, -100, 5);
 	}
 	emit_image(image, flags);
@@ -525,7 +525,7 @@ int main(int argc, char* argv[]) {
 	  cimg_library::CImg<unsigned char> original = load_rgb_CImg(name.c_str());
 	  unsigned int cut = name.find_last_of("/");
 	  sb += cut == std::string::npos ? name : name.substr(cut + 1);
-	  size newSize = fit_within(maxThumbSize, size(original));
+	  size newSize = size(original).fitted_within(maxThumbSize);
 	  original.resize(newSize.width, newSize.height, 1, -100, 5);
 	  image.draw_image(count * (tw + 8) + (tw - newSize.width) / 2, (tw - newSize.height) / 2, 0, 0, original);
 	  count++;

--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -382,6 +382,26 @@ void emit_image(const cimg_library::CImg<unsigned char> & image, int flags) {
 }
 
 
+struct size {
+  size(unsigned int in_width, unsigned int in_height) :
+	width(in_width), height(in_height) {
+  }
+  size(cimg_library::CImg<unsigned int> img) :
+	width(img.width()), height(img.height()) {
+  }
+  unsigned int width;
+  unsigned int height;
+};
+size operator*(size lhs, double scale) {
+  return size(lhs.width*scale, lhs.height*scale);
+}
+
+size fit_within(size container, size object) {
+  double scale = std::min(container.width / (double) object.width, container.height / (double) object.height);
+  return object * scale;
+}
+
+
 void emit_usage() {
   std::cerr << "Terminal Image Viewer" << std::endl << std::endl;
   std::cerr << "usage: tiv [options] <image> [<image>...]" << std::endl << std::endl;
@@ -472,8 +492,8 @@ int main(int argc, char* argv[]) {
 	cimg_library::CImg<unsigned char> image = load_rgb_CImg(file_names[i].c_str());
       
 	if (image.width() > maxWidth || image.height() > maxHeight) {
-	  double scale = std::min(maxWidth / (double) image.width(), maxHeight / (double) image.height());
-	  image.resize((int) (image.width() * scale), (int) (image.height() * scale), -100, -100, 5);
+	  size new_size = fit_within(size(maxWidth,maxHeight), size(image));
+	  image.resize(new_size.width, new_size.height, -100, -100, 5);
 	}
 	emit_image(image, flags);
       } catch(cimg_library::CImgIOException & e) {

--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -527,7 +527,7 @@ int main(int argc, char* argv[]) {
 	  sb += cut == std::string::npos ? name : name.substr(cut + 1);
 	  size newSize = fit_within(maxThumbSize, size(original));
 	  original.resize(newSize.width, newSize.height, 1, -100, 5);
-	  image.draw_image(count * (tw + 8), (tw - newSize.height) / 2, 0, 0, original);
+	  image.draw_image(count * (tw + 8) + (tw - newSize.width) / 2, (tw - newSize.height) / 2, 0, 0, original);
 	  count++;
 	  unsigned int sl = count * (cw + 2);
 	  sb.resize(sl - 2, ' ');


### PR DESCRIPTION
The aspect ratio of images is preserved in thumbnail mode.

I extracted the resizing logic for full mode and put it in place for thumbnail mode.

Should resolve https://github.com/stefanhaustein/TerminalImageViewer/issues/48