### PR TITLE
Extend Makefile for cross-compiling

### DIFF
--- a/src/main/cpp/Makefile
+++ b/src/main/cpp/Makefile
@@ -1,15 +1,22 @@
-CXX=g++
+# set CXX to g++ if not set
+CXX ?= g++
 
-default: tiv
+# append necessary arguments
+override CPPFLAGS += -std=c++17 -Wall -fpermissive -fexceptions -O2
+override LDFLAGS  += -lstdc++fs -pthread -s
+
+all: tiv
 
 tiv.o: tiv.cpp CImg.h
-	$(CXX) -std=c++17  -Wall -fpermissive -fexceptions -O2 -c tiv.cpp -o tiv.o
+	$(CXX) $(CPPFLAGS) -c tiv.cpp -o $@
 
 tiv : tiv.o
-	$(CXX) tiv.o -o tiv -lstdc++fs -pthread -s
+	$(CXX) $^ -o $@ $(LDFLAGS)
 
-install: tiv
-	cp tiv /usr/local/bin/tiv
+.PHONY: all install clean
+install: all
+	test -d $(DESTDIR)/usr/local/bin || mkdir -p $(DESTDIR)/usr/local/bin
+	cp tiv $(DESTDIR)/usr/local/bin/tiv
 
 clean:
-	rm -f tiv tiv.o 
+	rm -f tiv tiv.o


### PR DESCRIPTION
Modification of Makefile to allow passing of CPPFLAGS, LDFLAGS, CXX and DESTDIR. Works for me with Linux, cross-compiling and macOS.

Btw: I do use c++11 instead of c++17 in the hope for older gcc to work with it (not in this PR).

/Thomas