### PR TITLE
Replace best_diff when a better diff comes along

### DIFF
--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -301,8 +301,10 @@ int best_index(int value, const int data[], int count) {
   int best_diff = std::abs(data[0] - value);
   int result = 0;
   for (int i = 1; i < count; i++) {
-    if (std::abs(data[i] - value) < best_diff) {
+    int diff = std::abs(data[i] - value);
+    if (diff < best_diff) {
       result = i;
+      best_diff = diff;
     }
   }
   return result;  


### PR DESCRIPTION
I noticed an issue when using `-256` where the color palette isn't as good a fit as it could be. This seems to fix it; here is my github avatar in three versions:

- *(a)* - full colour version.
- *(b)* - 256 colour version before this patch
- *(c)* - 256 colour version after.

<img width="276" alt="Screen Shot 2019-10-15 at 00 59 50" src="https://user-images.githubusercontent.com/288426/66757223-6623f780-eee7-11e9-81ef-4ce1bd57c2e8.png">
