### PR TITLE
Fix std::array initialization error

### DIFF
--- a/src/main/cpp/tiv.cpp
+++ b/src/main/cpp/tiv.cpp
@@ -122,8 +122,8 @@ const unsigned int BITMAPS[] = {
 
 
 struct CharData {
-  std::array<int, 3> fgColor = {0};
-  std::array<int, 3> bgColor = {0};
+  std::array<int, 3> fgColor = std::array<int, 3>{0, 0, 0};
+  std::array<int, 3> bgColor = std::array<int, 3>{0, 0, 0};
   int codePoint;
 };
 


### PR DESCRIPTION
With the default compiler and Makefile settings, I ran into a compilation error after running `make`. This quick fix removed the errors and allowed me to make and install the tool.