### PR TITLE
Fedora Packaging Specfile

### DIFF
--- a/TerminalImageViewer.spec
+++ b/TerminalImageViewer.spec
@@ -1,0 +1,47 @@
+Name:           TerminalImageViewer
+Version:        1.1.1
+Release:        1%{?dist}
+Summary:        Display images in a terminal using block graphic characters
+
+License:        ASL 2.0
+URL:            https://github.com/stefanhaustein/TerminalImageViewer
+Source0:        https://github.com/stefanhaustein/TerminalImageViewer/archive/refs/tags/v%{version}.tar.gz
+
+BuildRequires:  g++
+BuildRequires:  make
+Requires:       ImageMagick-c++
+
+%define debug_package %{nil}
+
+%description
+Small C++ program to display images in a (modern) terminal using RGB ANSI codes
+and unicode block graphic characters. There are various similar tools (such as
+`timg`) using the unicode half block character to display two 24bit pixels per
+character cell. This program enhances the resolution by mapping 4x8 pixel cells
+to different unicode characters.
+
+
+%prep
+%autosetup
+
+
+%build
+cd ./src/main/cpp
+%make_build
+
+
+%install
+cd ./src/main/cpp
+%make_install
+
+
+%files
+%{_exec_prefix}/local/bin/tiv
+%license LICENSE
+%doc README.md
+
+
+
+%changelog
+* Sat Jun 11 2022 Marko Vejnovic <contact@markovejnovic.com> 1.1.1
+- Initialization Error Fix


### PR DESCRIPTION
Hi! I am currently running a Fedora 35. I decided to package this software. It should work on both 35 and 36 without a hitch. I decided to dump a `.spec` file that you can use to build the package for `fedora` systems. I'm not sure about all `rpm`-based systems, but this does work for Fedora.

### How can we test this? Step by step instructions please.

You can check out these changes with something like this:
```bash
mkdir build
cp TerminalImageViewer.spec build
cd build
wget https://github.com/stefanhaustein/TerminalImageViewer/archive/refs/tags/v1.1.1.tar.gz
fedpkg --release f35 mockbuild
sudo dnf install -C -y results_TerminalImageViewer/1.1.1/1.fc35/TerminalImageViewer-1.1.1-1.fc35.x86_64.rpm
```

I hope this is useful for you. As of now I'll leave it at this but I will upload this to COPR at one point for automatic builds.