### PR TITLE
Add link to discussions as question template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: "Question"
+    url: https://github.com/stefanhaustein/TerminalImageViewer/discussions/new
+    about: Ask things about the project

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Question"
-    url: https://github.com/stefanhaustein/TerminalImageViewer/discussions/new
+    url: https://github.com/stefanhaustein/TerminalImageViewer/discussions/new?category=q-a
     about: Ask things about the project

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,0 @@
----
-name: Question
-about: Asks things about the project
-title: ''
-labels: question
-assignees: ''
-
----

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!--Closes #0-->
 <!--(if any, change the zero above to the issue number and uncomment lines 1 and 2)-->
 
-### How can we test this? Step by step instructions please.
+### How can we test this? Step-by-step instructions, please.
 
 1. 
 2. 


### PR DESCRIPTION
<!--**Issue related to pull request**-->
<!--Closes #0-->
<!--(if any, change the zero above to the issue number and uncomment lines 1 and 2)-->

### How can we test this? Step-by-step instructions, please.

1. Click on "new issue" [in my fork](https://github.com/aaronliu0130/TerminalImageViewer/issues/new/choose)
2. Click on the "open" button next to "question"

### What happened before?
People might not know about discussions

### What should happen with this fix?
People can know about it when attempting to create a question issue

### Anything else we should know about this patch?
I hate mobile coding