### PR TITLE
Add ability to define custom background colors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,33 +3,33 @@ name: Build and run
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
-    paths: ['src/**']
+    branches: ["master"]
+    paths: ["src/**"]
   pull_request:
-    paths: ['src/**']
+    paths: ["src/**"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install dependencies
-      run: sudo apt-get install -qy imagemagick
-    - name: Validate gcc version
-      run: |
-        if [[ $(gcc --version | awk '/gcc/ && ($3+0)>13{print "gcc-13+"}') != "gcc-13+" ]]; then
-          # Script courtesy of https://stackoverflow.com/a/67791068/16134571
-          sudo apt install gcc-13 g++-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
-          sudo update-alternatives --set gcc /usr/bin/gcc-13
-        fi
-    - name: Build
-      run: make -C src
-    - name: Test
-      run: |
-        images=('/usr/local/share/icons/hicolor/128x128/apps/microsoft-edge.png' '/usr/local/share/icons/hicolor/128x128/apps/CMakeSetup.png' '/usr/local/doc/cmake/html/_static/file.png' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/tagmanager/cuteanimals/res/drawable/cat_1.jpg' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/wallet/res/drawable-ldpi/icon.png' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/wallet/res/drawable-hdpi/icon.png' '/usr/share/plymouth/themes/spinner/watermark.png' '/usr/share/apache2/icons/apache_pb.png' '/usr/share/doc/libpng-dev/examples/pngtest.png')
-        image=${images[ $RANDOM % ${#images[@]} ]} # Get random image
-        ./src/tiv -w 160 -h 48 $image # Get random image
-        echo $image
-        ./src/tiv -w 160 -h 48 /usr/share/pixmaps # Dir mode
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get install -qy imagemagick libpng-dev
+      - name: Validate gcc version
+        run: |
+          if [[ $(gcc --version | awk '/gcc/ && ($3+0)>13{print "gcc-13+"}') != "gcc-13+" ]]; then
+            # Script courtesy of https://stackoverflow.com/a/67791068/16134571
+            sudo apt install gcc-13 g++-13
+            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+            sudo update-alternatives --set gcc /usr/bin/gcc-13
+          fi
+      - name: Build
+        run: make -C src
+      - name: Test
+        run: |
+          images=('/usr/local/share/icons/hicolor/128x128/apps/microsoft-edge.png' '/usr/local/share/icons/hicolor/128x128/apps/CMakeSetup.png' '/usr/local/doc/cmake/html/_static/file.png' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/tagmanager/cuteanimals/res/drawable/cat_1.jpg' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/wallet/res/drawable-ldpi/icon.png' '/usr/local/lib/android/sdk/extras/google/google_play_services/samples/wallet/res/drawable-hdpi/icon.png' '/usr/share/plymouth/themes/spinner/watermark.png' '/usr/share/apache2/icons/apache_pb.png' '/usr/share/doc/libpng-dev/examples/pngtest.png')
+          image=${images[ $RANDOM % ${#images[@]} ]} # Get random image
+          ./src/tiv -w 160 -h 48 $image # Get random image
+          echo $image
+          ./src/tiv -w 160 -h 48 /usr/share/pixmaps # Dir mode

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ bindir      ?= $(exec_prefix)/bin
 
 override CXXFLAGS += -std=c++17 -Wall -fexceptions
 override LDFLAGS  += -pthread
+override LDLIBS   += -lpng
 
 all: $(PROGNAME)
 

--- a/src/tiv_lib.h
+++ b/src/tiv_lib.h
@@ -60,6 +60,8 @@ constexpr int GRAYSCALE_STEPS[GRAYSCALE_STEP_COUNT] = {
 
 typedef std::function<unsigned long(int, int)> GetPixelFunction;
 
+unsigned char get_channel(unsigned long rgb, int index);
+
 int clamp_byte(int value);
 
 int best_index(int value, const int STEPS[], int count);


### PR DESCRIPTION
**Issue related to pull request**-->
Closes #112 -->
<!--(if any, change the zero above to the issue number and uncomment lines 1 and 2)-->

### How can we test this? Step-by-step instructions, please.

1. Run with new option '-C' and use hex number as argument

### What happened before?
PNGs and GIFs with transparency loaded with ImageMagick which filled in the background as white, with no way to change it.

### What should happen with this fix?
If '-C' is unspecified, the background still defaults to white. 
If a hex number is passed in, the background will be that color.

### Anything else we should know about this patch?
Libpng is now required in order to load transparent images properly.  
